### PR TITLE
Use iotools::ctapply instead of tapply

### DIFF
--- a/Exercise_10_ParticleFilter.Rmd
+++ b/Exercise_10_ParticleFilter.Rmd
@@ -184,10 +184,12 @@ output[is.nan(output)] = 0
 output[is.infinite(output)] = 0
 
 ## average the output to daily
+library(iotools)
 bin = 86400/timestep
 out.daily = array(0.0,c(ceiling(nt/bin),ne,12))
 for(i in 1:12){
-  out.daily[,,i] <- apply(output[,,i],2,function(x){tapply(x,rep(1:365,each=bin)[1:nt],mean)})
+  print(i)
+  out.daily[,,i] <- apply(output[,,i],2, ctapply, rep(1:365,each=bin)[1:nt], mean)
 }
 
 ## Basic time-series visualizations


### PR DESCRIPTION
On my machine, this is sheds about 1.5s (2s instead of 3.5) off of each daily aggregation (so x12 = 18 seconds from this step). You can speed this up a lot more by using `data.table`, but that requires reshaping the data to long form first and some other stuff that may not be worth it.
