### PR TITLE
Fix package install that prevents html document from compiling

### DIFF
--- a/Exercise_03_BigData.Rmd
+++ b/Exercise_03_BigData.Rmd
@@ -204,6 +204,7 @@ ds
 ```
 At this point, ds is just a connection to a cloud service, but it behaves like a dataframe. We can use standard tidyverse syntax to process this file (e.g. filtering by time and location) and only when we call the command `collect()` does the processing actually execute in the cloud and send us the data we're requesting. For example, in the following command we request the phenology forecasts of the Phenocam greeness variable `gcc_90` for the NEON Harvard Forest site (HARV).
 ```{r}
+library(tidyverse)
 df <- ds %>% 
   filter(theme == "phenology", 
          variable=="gcc_90",

--- a/Exercise_04_PairCoding_NEON.Rmd
+++ b/Exercise_04_PairCoding_NEON.Rmd
@@ -6,7 +6,7 @@ output: html_document
 
 ## Before getting started
 
-Before beginning this exercise, you should have the following thre pacakges installed, which you may not already have installed. If you don't have them installed, you should run the following commands **in your console** to install them. The reason for this is RMarkdown really doesn't like when you try to install packages while knitting a document. So, while you *can* run the code chunk by chunk in RMarkdown, if you go to knit it, you will receive an error.
+Before beginning this exercise, you should have the following three packages installed, which you may not already have installed. If you don't have them installed, you should run the following commands **in your console** to install them. The reason for this is RMarkdown really doesn't like when you try to install packages while knitting a document. So, while you *can* run the code chunk by chunk in RMarkdown, if you go to knit it, you will receive an error.
 
         devtools::install_github('eco4cast/neon4cast')
         

--- a/Exercise_04_PairCoding_NEON.Rmd
+++ b/Exercise_04_PairCoding_NEON.Rmd
@@ -4,6 +4,16 @@ author: "Michael Dietze"
 output: html_document
 ---
 
+## Before getting started
+
+Before beginning this exercise, you should have the following thre pacakges installed, which you may not already have installed. If you don't have them installed, you should run the following commands **in your console** to install them. The reason for this is RMarkdown really doesn't like when you try to install packages while knitting a document. So, while you *can* run the code chunk by chunk in RMarkdown, if you go to knit it, you will receive an error.
+
+        devtools::install_github('eco4cast/neon4cast')
+        
+        install.packages('rMR')
+        
+        devtools::install_github('eco4cast/EFIstandards')
+        
 ## Objectives
 
 The primary goal of this exercise is to gain experience working collaboratively to develop a scientific workflow. As such, this assignment is best completed with a partner. Specifically, we will outline a simple analysis, break the overall job into parts, and have each person complete part of the project. To put these parts together we will be using Github. Along the way we will also be exploring the statistical concept of Likelihood.
@@ -410,7 +420,7 @@ git pull upstream master
 library(tidyverse)
 library(neon4cast)
 library(lubridate)
-install.packages("rMR")
+#install.packages("rMR")
 library(rMR)
 
 forecast_date <- Sys.Date()


### PR DESCRIPTION
If folks don't have the packages installed, they can run chunk by chunk but cannot compile the html document. I added a section at the beginning of the markdown doc explaining this and offering a solution.